### PR TITLE
Improve copyProperties() performance.

### DIFF
--- a/STANDARD/gen1/pokemon_red_blue.js
+++ b/STANDARD/gen1/pokemon_red_blue.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 /** Generate a nibble from each IV's respective bit */

--- a/STANDARD/gen1/pokemon_yellow.js
+++ b/STANDARD/gen1/pokemon_yellow.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 /** Generate a nibble from each IV's respective bit */

--- a/STANDARD/gen2/pokemon_crystal.js
+++ b/STANDARD/gen2/pokemon_crystal.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 const HIDDEN_POWER_TYPES = [

--- a/STANDARD/gen2/pokemon_gold_silver.js
+++ b/STANDARD/gen2/pokemon_gold_silver.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 const HIDDEN_POWER_TYPES = [

--- a/STANDARD/gen3/pokemon_emerald.js
+++ b/STANDARD/gen3/pokemon_emerald.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 //Decryption Functions

--- a/STANDARD/gen3/pokemon_firered_leafgreen.js
+++ b/STANDARD/gen3/pokemon_firered_leafgreen.js
@@ -51,17 +51,19 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
+
 
 // //Decryption Functions
 // //16-bit and 32-bit data access functions

--- a/STANDARD/gen3/pokemon_ruby_sapphire.js
+++ b/STANDARD/gen3/pokemon_ruby_sapphire.js
@@ -51,16 +51,17 @@ function setProperty(path, values) {
     if (values.value !== undefined)
         property.value = values.value;
 }
+
 function copyProperties(sourcePath, destinationPath) {
-    const sourceProps = Object.values(mapper.properties).filter(x => x.path.startsWith(sourcePath));
-    const destinationProps = Object.values(mapper.properties).filter(x => x.path.startsWith(destinationPath));
-    destinationProps.forEach(property => {
-        const restOfThePath = property.path.replace(destinationPath, '');
-        const source = sourceProps.find(x => x.path === `${sourcePath}${restOfThePath}`);
-        if (source) {
-            setProperty(property.path, source);
-        }
-    });
+	const destPathLength = destinationPath.length;
+	Object.keys(mapper.properties)
+		.filter(key => key.startsWith(destinationPath))
+		.forEach((key) => {
+			const source = mapper.properties[`${sourcePath}${key.slice(destPathLength)}`];
+			if (source) {
+				setProperty(key, source);
+			}
+		});
 }
 
 function DATA32_LE(data, offset) {


### PR DESCRIPTION
For some reason `Object.values()` is rather expensive in Jint, the JS engine used by PokeAByte. The new implementation avoids one `values()` call completey and uses `Object.keys` in place of the other, because that does not seem to have quite the same penalty.

I also slightly improved how we create the source path.

This mapper change reduces the CPU load (on one core) for the "pokemon_emerald" mapper on my working branch of PokeAByte from ~11% to ~7.2%. And for "pokemon_yellow" it goes from ~30% down to ~17%,