### PR TITLE
Define necessary memory regions in yellow, crystal and emerald mappers.

### DIFF
--- a/DEPRECATED/gen1/pokemon_yellow_deprecated.xml
+++ b/DEPRECATED/gen1/pokemon_yellow_deprecated.xml
@@ -12,7 +12,16 @@ For all new software, please use the paths within 'pokemon_yellow.xml'
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
-
+	<memory>
+		<!-- "Header                  <read start="0x0000" end="0x00FF" /> --> 
+		<!-- "VRAM                --> <read start="0x8000" end="0x9FFF" />
+		<!-- "External RAM Part 1     <read start="0xA000" end="0xAFFF" /> --> 
+		<!-- "External RAM Part 2     <read start="0xB000" end="0xBFFF" /> --> 
+		<!-- "Work RAM Bank 0     --> <read start="0xC000" end="0xCFFF" />
+		<!-- "Work RAM Bank 1     --> <read start="0xD000" end="0xDFFF" />
+		<!-- "I/O Registers           <read start="0xFF00" end="0xFF7F" /> --> 
+		<!-- "High RAM            --> <read start="0xFF80" end="0xFFFE" />
+	</memory>
 	<classes>
 		<pokemonInParty>
 			<property name="nickname" type="string" address="{nicknameAddress}" length="11" macro="pokemonMacro" />

--- a/DEPRECATED/gen2/pokemon_crystal_deprecated.xml
+++ b/DEPRECATED/gen2/pokemon_crystal_deprecated.xml
@@ -12,7 +12,20 @@ For all new software, please use the paths within 'pokemon_crystal.xml'
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
-
+	<memory>
+		<!-- Header                  <read start="0x0000" end="0x00FF" /> --> 
+		<!-- VRAM                --> <read start="0x8000" end="0x9FFF" />
+		<!-- External RAM Bank 1     <read start="0xA000" end="0xAFFF" /> --> 
+		<!-- External RAM Bank 2     <read start="0xB000" end="0xBFFF" /> --> 
+		<!-- Work RAM Bank 0     --> <read start="0xC000" end="0xCFFF" />
+		<!-- Work RAM Bank 1     --> <read start="0xD000" end="0xDFFF" />
+		<!-- I/O Registers           <read start="0xFF00" end="0xFF7F" /> --> 
+		<!-- High RAM            --> <read start="0xFF80" end="0xFFFE" />
+		<!-- Work RAM (Bank 2)   --> <read start="0x10000" end="0x10FFF" />
+		<!-- Work RAM (Bank 3)       <read start="0x11000" end="0x11FFF" /> -->
+		<!-- Work RAM (Bank 6)       <read start="0x14000" end="0x14FFF" /> -->
+		<!-- Work RAM (Bank 7)       <read start="0x15000" end="0x15FFF" /> -->
+	</memory>
     <classes>
         <pokemonInParty>
             <property name="nickname"      address="{nicknameAddress}" type="string" reference="defaultCharacterMap" length="11" />

--- a/STANDARD/gen1/pokemon_yellow.xml
+++ b/STANDARD/gen1/pokemon_yellow.xml
@@ -4,6 +4,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
+	<memory>
+		<!-- "Header                  <read start="0x0000" end="0x00FF" /> --> 
+		<!-- "VRAM                --> <read start="0x8000" end="0x9FFF" />
+		<!-- "External RAM Part 1     <read start="0xA000" end="0xAFFF" /> --> 
+		<!-- "External RAM Part 2     <read start="0xB000" end="0xBFFF" /> --> 
+		<!-- "Work RAM Bank 0     --> <read start="0xC000" end="0xCFFF" />
+		<!-- "Work RAM Bank 1     --> <read start="0xD000" end="0xDFFF" />
+		<!-- "I/O Registers           <read start="0xFF00" end="0xFF7F" /> --> 
+		<!-- "High RAM            --> <read start="0xFF80" end="0xFFFE" />
+	</memory>
     <macros>
         <pokemon>
             <property name="species"    type="int" address="{address}" reference="species" />

--- a/STANDARD/gen2/pokemon_crystal.xml
+++ b/STANDARD/gen2/pokemon_crystal.xml
@@ -4,6 +4,24 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
+	<memory>
+		<!-- EWRAM Block 01     <read start="0x0000000" end="0x0003FFF" /> -->
+		<!-- EWRAM Block 02     <read start="0x2020000" end="0x2020FFF" /> -->
+		<!-- EWRAM Block 03 --> <read start="0x2021000" end="0x2022FFF" />
+		<!-- EWRAM Block 04 --> <read start="0x2023000" end="0x2023FFF" />
+		<!-- EWRAM Block 05 --> <read start="0x2024000" end="0x2027FFF" />
+		<!-- EWRAM Block 06 --> <read start="0x2030000" end="0x2033FFF" />
+		<!-- EWRAM Block 07 --> <read start="0x2037000" end="0x2039999" />
+		<!-- EWRAM Block 08     <read start="0x203A000" end="0x203AFFF" /> -->
+		<!-- EWRAM Block 09     <read start="0x203B000" end="0x203BFFF" /> -->
+		<!-- EWRAM Block 10 --> <read start="0x203C000" end="0x203CFFF" />
+		<!-- EWRAM Block 11     <read start="0x203D000" end="0x203DFFF" /> -->
+
+		<!-- IWRAM Block 1      --> <read start="0x03001000" end="0x03004FFF" />
+		<!-- IWRAM Block 2 --> <read start="0x03005000" end="0x03005FFF" />
+		<!-- IWRAM Block 3     <read start="0x03006000" end="0x03006FFF" /> -->
+		<!-- IWRAM Block 4 --> <read start="0x03007000" end="0x03007FFF" />
+	</memory>
     <macros>
         <pokemon>
             <property name="species"    type="int" address="{address}" reference="species" />

--- a/STANDARD/gen3/pokemon_emerald.xml
+++ b/STANDARD/gen3/pokemon_emerald.xml
@@ -4,6 +4,24 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
+	<memory>
+		<!-- EWRAM Block 01     <read start="0x00000000" end="0x00003FFF" /> -->
+		<!-- EWRAM Block 02     <read start="0x02020000" end="0x02020FFF" /> -->
+		<!-- EWRAM Block 03 --> <read start="0x02021000" end="0x02022FFF" />
+		<!-- EWRAM Block 04 --> <read start="0x02023000" end="0x02023FFF" />
+		<!-- EWRAM Block 05 --> <read start="0x02024000" end="0x02027FFF" />
+		<!-- EWRAM Block 06 --> <read start="0x02030000" end="0x02033FFF" />
+		<!-- EWRAM Block 07     <read start="0x02037000" end="0x02039999" /> -->
+		<!-- EWRAM Block 08     <read start="0x0203A000" end="0x0203AFFF" /> -->
+		<!-- EWRAM Block 09     <read start="0x0203B000" end="0x0203BFFF" /> -->
+		<!-- EWRAM Block 10     <read start="0x0203C000" end="0x0203CFFF" /> -->
+		<!-- EWRAM Block 11     <read start="0x0203D000" end="0x0203DFFF" /> -->
+
+		<!-- IWRAM Block 1     <read start="0x03001000" end="0x03004FFF" />-->
+		<!-- IWRAM Block 2 --> <read start="0x03005000" end="0x03005FFF" />
+		<!-- IWRAM Block 3     <read start="0x03006000" end="0x03006FFF" /> -->
+		<!-- IWRAM Block 4 --> <read start="0x03007000" end="0x03007FFF" />
+	</memory>
     <classes>
         <party_pokemon>
             <property name="species"    type="int"    address="32"       memoryContainer="{memoryContainer}" length="2" reference="species" />


### PR DESCRIPTION
This reduces the number of reads against the emulator, lessening the CPU load of both the emulator and PokeAByte.

It would be possible to further reduce the memory regions by restricting the size of individual blocks, but this might impair maintainability of the mappers.