### PR TITLE
Performance: Use mapper.copy_properties when available.

### DIFF
--- a/DEPRECATED/gen2/pokemon_crystal_deprecated.xml
+++ b/DEPRECATED/gen2/pokemon_crystal_deprecated.xml
@@ -317,9 +317,9 @@ For all new software, please use the paths within 'pokemon_crystal.xml'
       <property name="elm_called_about_stolen_pokemon" type="bool" address="0xDA7A" bits="3" />
     </events>
     <roamers>
-      <class name="0" type="roamer" address="0xDFCF" />
-      <class name="1" type="roamer" address="0xDFD6" />
-      <class name="2" type="roamer" address="0xDFDD" />
+      <class name="0" type="roamer" var:address="0xDFCF" />
+      <class name="1" type="roamer" var:address="0xDFD6" />
+      <class name="2" type="roamer" var:address="0xDFDD" />
     </roamers>
 
     <encounterRate>

--- a/STANDARD/gen1/pokemon_red_blue.js
+++ b/STANDARD/gen1/pokemon_red_blue.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen1/pokemon_yellow.js
+++ b/STANDARD/gen1/pokemon_yellow.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen2/pokemon_crystal.js
+++ b/STANDARD/gen2/pokemon_crystal.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen2/pokemon_gold_silver.js
+++ b/STANDARD/gen2/pokemon_gold_silver.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen3/pokemon_emerald.js
+++ b/STANDARD/gen3/pokemon_emerald.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen3/pokemon_emerald.xml
+++ b/STANDARD/gen3/pokemon_emerald.xml
@@ -5,22 +5,24 @@
     xsi:schemaLocation="https://schemas.pokeabyte.io/mapper https://schemas.pokeabyte.io/mapper.xsd"
     xmlns:var="https://schemas.pokeabyte.io/attributes/var">
 	<memory>
-		<!-- EWRAM Block 01     <read start="0x00000000" end="0x00003FFF" /> -->
-		<!-- EWRAM Block 02     <read start="0x02020000" end="0x02020FFF" /> -->
-		<!-- EWRAM Block 03 --> <read start="0x02021000" end="0x02022FFF" />
-		<!-- EWRAM Block 04 --> <read start="0x02023000" end="0x02023FFF" />
-		<!-- EWRAM Block 05 --> <read start="0x02024000" end="0x02027FFF" />
-		<!-- EWRAM Block 06 --> <read start="0x02030000" end="0x02033FFF" />
-		<!-- EWRAM Block 07     <read start="0x02037000" end="0x02039999" /> -->
-		<!-- EWRAM Block 08     <read start="0x0203A000" end="0x0203AFFF" /> -->
-		<!-- EWRAM Block 09     <read start="0x0203B000" end="0x0203BFFF" /> -->
-		<!-- EWRAM Block 10     <read start="0x0203C000" end="0x0203CFFF" /> -->
-		<!-- EWRAM Block 11     <read start="0x0203D000" end="0x0203DFFF" /> -->
+		<!-- EWRAM Block 01 <read start="0x00000000" end="0x00003FFF" /> -->
+		<!-- EWRAM Block 02 <read start="0x02020000" end="0x02020FFF" /> -->
+		<!-- EWRAM Block 03 --> <read start="0x02022FEC" end="0x020230FF" /> 
+		<!-- EWRAM Block 04 <read start="0x02023400" end="0x02023FFF" /> -->
+		<!-- EWRAM Block 05 --> <read start="0x0202406E" end="0x02026FFF" />
+		<!-- EWRAM Block 06 --> <read start="0x020322E4" end="0x020322E6" />
+		<!-- EWRAM Block 07 --> <read start="0x02037000" end="0x020375FF" /> 
+		<!-- EWRAM Block 07 --> <read start="0x02038B00" end="0x02038BFF" /> 
+		<!-- EWRAM Block 07 --> <read start="0x02039996" end="0x0203999F" /> 
+		<!-- EWRAM Block 08 <read start="0x0203A000" end="0x0203AFFF" />  -->
+		<!-- EWRAM Block 09 <read start="0x0203B000" end="0x0203BFFF" />  -->
+		<!-- EWRAM Block 10 --> <read start="0x0203CE00" end="0x0203CEFF" /> 
+		<!-- EWRAM Block 11 <read start="0x0203D000" end="0x0203DFFF" />  -->
 
-		<!-- IWRAM Block 1     <read start="0x03001000" end="0x03004FFF" />-->
-		<!-- IWRAM Block 2 --> <read start="0x03005000" end="0x03005FFF" />
-		<!-- IWRAM Block 3     <read start="0x03006000" end="0x03006FFF" /> -->
-		<!-- IWRAM Block 4 --> <read start="0x03007000" end="0x03007FFF" />
+		<!-- IWRAM Block 1 --> <read start="0x03002200" end="0x030022FF" />
+		<!-- IWRAM Block 2 --> <read start="0x03005D00" end="0x03005DFF" />
+		<!-- IWRAM Block 3 <read start="0x03006000" end="0x03006FFF" />  -->
+		<!-- IWRAM Block 4 --> <read start="0x03007500" end="0x030076FF" /> 
 	</memory>
     <classes>
         <party_pokemon>

--- a/STANDARD/gen3/pokemon_firered_leafgreen.js
+++ b/STANDARD/gen3/pokemon_firered_leafgreen.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))

--- a/STANDARD/gen3/pokemon_ruby_sapphire.js
+++ b/STANDARD/gen3/pokemon_ruby_sapphire.js
@@ -53,6 +53,10 @@ function setProperty(path, values) {
 }
 
 function copyProperties(sourcePath, destinationPath) {
+	if (mapper.copy_properties) {
+		mapper.copy_properties(sourcePath, destinationPath);
+		return;
+	}
 	const destPathLength = destinationPath.length;
 	Object.keys(mapper.properties)
 		.filter(key => key.startsWith(destinationPath))


### PR DESCRIPTION
This reduces the CPU load on Poke-A-Byte by quite a bit. Single core load for the emerald mapper goes down from 43 to 30% on my machine when on version 0.8.0 or newer.